### PR TITLE
setsid returns -1 on error

### DIFF
--- a/lib/Proc/Fork.pm
+++ b/lib/Proc/Fork.pm
@@ -231,7 +231,7 @@ If an C<error> clause is not used, errors will raise an exception using C<die>.
 
  # Other daemon initialization activities.
  $SIG{INT} = $SIG{TERM} = $SIG{HUP} = $SIG{PIPE} = \&some_signal_handler;
- POSIX::setsid() or die "Cannot start a new session: $!\n";
+ POSIX::setsid() == -1 and die "Cannot start a new session: $!\n";
  close $_ for *STDIN, *STDOUT, *STDERR;
 
  # rest of daemon program follows


### PR DESCRIPTION
setsid returns -1 on error.
```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid(); print "ret:$ret, errno:$!"'
ret:-1, errno:Operation not permitted
```